### PR TITLE
fix: allow s3 path in prefix

### DIFF
--- a/src/metrics/metric.ts
+++ b/src/metrics/metric.ts
@@ -22,6 +22,7 @@ export abstract class Metric {
   name (): string {
     return `s3_${this.metricName}_${this.prefix}`
       .replaceAll("-", "_")
+      .replaceAll("/", "_")
       .toLowerCase();
   }
 


### PR DESCRIPTION
This changes allows to have a path as a prefix

`postgres/database-backup` => `postgres_database_backup`